### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/dns_updater/api/__init__.py
+++ b/dns_updater/api/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import print_function
 from flask import (Blueprint)
 from oslo.config import cfg
 
@@ -38,6 +39,6 @@ def update_conf(update_type, group_name, params):
     if group_name != CONF.host_group:
         return send_alarm_email(
             u'Host %s group not match: local %s, param: %s' % (CONF.host_ip, CONF.host_group, group_name))
-    print update_type, params
+    print(update_type, params)
     start_update_thread(update_type, group_name=group_name, **params)
     return

--- a/dns_updater/utils/updater_util.py
+++ b/dns_updater/utils/updater_util.py
@@ -17,6 +17,11 @@ from dnsdb_common.library.email_util import send_email
 from dnsdb_common.library.exception import UpdaterErr
 from dnsdb_common.library.log import getLogger
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 log = getLogger(__name__)
 
 CONF = cfg.CONF

--- a/dns_updater/workers/zone_worker.py
+++ b/dns_updater/workers/zone_worker.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from dns_updater.utils.updater_util import *
 
 TMP_DIR = CONF.etc.tmp_dir
@@ -83,7 +84,7 @@ def handler(self):
             if DnsdbApi.can_reload():
                 reload_and_backup_zones(zone_file_dict)
                 DnsdbApi.update_zone_serial(name)
-                print 'update_zone_serial'
+                print('update_zone_serial')
             return True
         except UpdaterErr as e:
             log.error(e.message)

--- a/dnsdb/deploy.py
+++ b/dnsdb/deploy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import json
 import threading
 import time
@@ -75,7 +76,7 @@ class DeployThread(threading.Thread):
         job = OperationLogDal.get_deploy_job(self.job_id)
         data = dict(op_result='ok')
         data['op_after'] = json.loads(job.op_after)
-        print json.dumps(data['op_after'], indent=4)
+        print(json.dumps(data['op_after'], indent=4))
         if self.unfinished:
             data['op_result'] = 'fail'
             data['op_after']['unfinished'] = self.unfinished
@@ -90,8 +91,8 @@ class DeployThread(threading.Thread):
             hosts = info['hosts']
             for host_ip in hosts:
                 try:
-                    print DnsUpdaterApi(host_ip=host_ip).notify_update(self.deploy_type, group_name,
-                                                                       group_conf_md5=conf_md5, deploy_id=self.job_id)
+                    print(DnsUpdaterApi(host_ip=host_ip).notify_update(self.deploy_type, group_name,
+                                                                       group_conf_md5=conf_md5, deploy_id=self.job_id))
                 except Exception as e:
                     log.error('notify %s to update %s failed, %s' % (host_ip, self.deploy_type, e))
                     self.notify_failed.append(host_ip)
@@ -105,8 +106,8 @@ class DeployThread(threading.Thread):
         for group_name, hosts in hosts.iteritems():
             for host in hosts:
                 try:
-                    print DnsUpdaterApi(host_ip=host).notify_update(self.deploy_type, group_name,
-                                                                    deploy_id=self.job_id, acl_files=acl_files)
+                    print(DnsUpdaterApi(host_ip=host).notify_update(self.deploy_type, group_name,
+                                                                    deploy_id=self.job_id, acl_files=acl_files))
                 except Exception as e:
                     log.error('notify %s to update %s failed, %s' % (host, self.deploy_type, e))
                     self.notify_failed.append(e)

--- a/dnsdb/view/api/__init__.py
+++ b/dnsdb/view/api/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import print_function
 from flask import (Blueprint)
 
 from dnsdb_common.dal.host_group_conf import HostGroupConfDal
@@ -85,5 +86,5 @@ def get_zone_info(zone_name):
 @parse_params([dict(name='zone_name', type=str, required=True, nullable=False)])
 @resp_wrapper_json
 def update_zone_serial(zone_name):
-    print zone_name
+    print(zone_name)
     return ZoneRecordDal.update_serial_num(zone_name)

--- a/dnsdb/view/web/root.py
+++ b/dnsdb/view/web/root.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import print_function
 from flask import (abort, Blueprint)
 from flask import render_template, url_for
 from flask_login import login_required
@@ -14,8 +15,8 @@ bp = Blueprint('root', 'root')
 @bp.route("/api/", methods=['GET'])
 def root(path=''):
     try:
-        print url_for('static', filename='index.html')
-        print url_for('static', filename='favicon.ico')
+        print(url_for('static', filename='index.html'))
+        print(url_for('static', filename='favicon.ico'))
         return render_template('index.html')
     except TemplateNotFound:
         abort(404)

--- a/dnsdb/view/web/user.py
+++ b/dnsdb/view/web/user.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import re
 
 from flask import (Blueprint)
@@ -70,7 +71,7 @@ def get_user(username):
                dict(name='role_id', type=str, required=False, nullable=False)])
 @resp_wrapper_json
 def list_user(**kwargs):
-    print kwargs
+    print(kwargs)
     return UserDal.list_user(**kwargs)
 
 

--- a/dnsdb_command.py
+++ b/dnsdb_command.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import json
 import os
 import re
@@ -85,7 +86,7 @@ def parse_zone_file(zone_name, zone_file, user, only_a=False):
 
     for parts in records:
         if len(parts) != 4 and len(parts) != 5:
-            print zone_name, ": ", parts
+            print(zone_name, ": ", parts)
             continue
 
         # 获得完整的域名
@@ -263,7 +264,7 @@ def import_acl_subnet(acl_dir, user, add_overlap=True):
     if isp_config:
         with db.session.begin(subtransactions=True):
             db.session.bulk_insert_mappings(ViewIsps, isp_config)
-        print 'add isp conf success'
+        print('add isp conf success')
 
     overlap = {}
     for item in ViewIsps.query.all():
@@ -275,7 +276,7 @@ def import_acl_subnet(acl_dir, user, add_overlap=True):
         if not os.path.exists(acl_path):
             continue
         if ViewAclSubnet.query.filter_by(origin_acl=acl_name).first():
-            print 'There already have subnet for %s in database' % acl_name
+            print('There already have subnet for %s in database' % acl_name)
 
         overlap_subnets, subnets = parse_acl_file(acl_path)
         if overlap_subnets:
@@ -297,5 +298,5 @@ def import_acl_subnet(acl_dir, user, add_overlap=True):
             db.session.bulk_insert_mappings(ViewAclSubnet, subnet_mapping)
 
     if overlap:
-        print 'There are overlap_subnets in files:'.format(overlap.keys())
-        print json.dumps(overlap, indent=4)
+        print('There are overlap_subnets in files:'.format(overlap.keys()))
+        print(json.dumps(overlap, indent=4))

--- a/dnsdb_common/dal/operation_log.py
+++ b/dnsdb_common/dal/operation_log.py
@@ -8,6 +8,11 @@ from . import db, commit_on_success
 from .models import OperationLog
 from .models import OperationLogDetail
 
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
+
 
 def format_time(time_str, time_type):
     if time_type == 'start':
@@ -41,7 +46,7 @@ class OperationLogDal(object):
     @staticmethod
     def add_log_detail(log_id, reason):
         session = db.session
-        if not isinstance(reason, (str, unicode)):
+        if not isinstance(reason, basestring):
             reason = str(reason)
         if len(reason) > 1024:
             reason = reason[:1024]

--- a/dnsdb_common/dal/view_record.py
+++ b/dnsdb_common/dal/view_record.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import json
 from collections import defaultdict
 
@@ -288,7 +289,7 @@ class ViewRecordDal(object):
     @staticmethod
     @commit_on_success
     def increase_serial_num(zone_name):
-        print 'increase_serial_num: ', zone_name
+        print('increase_serial_num: ', zone_name)
         serials = DnsSerial.query.filter_by(zone_name=zone_name).all()
         if len(serials) != 1:
             raise BadParam('Zone serial should be unique: %s' % zone_name, msg_ch=u'zone serial记录不存在或者不唯一')

--- a/dnsdb_common/library/IPy.py
+++ b/dnsdb_common/library/IPy.py
@@ -119,13 +119,13 @@ MAX_IPV6_ADDRESS = 0xffffffffffffffffffffffffffffffff
 IPV6_TEST_MAP = 0xffffffffffffffffffffffff00000000
 IPV6_MAP_MASK = 0x00000000000000000000ffff00000000
 
-if sys.version_info >= (3,):
+try:               # Python 2
+    INT_TYPES = (int, long)
+    STR_TYPES = (str, unicode)
+except NameError:  # Python 3
     INT_TYPES = (int,)
     STR_TYPES = (str,)
     xrange = range
-else:
-    INT_TYPES = (int, long)
-    STR_TYPES = (str, unicode)
 
 
 class IPint(object):

--- a/dnsdb_common/library/decorators.py
+++ b/dnsdb_common/library/decorators.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import json
 from datetime import datetime
 from functools import wraps
@@ -13,6 +14,11 @@ from ..dal.operation_log import OperationLogDal
 from ..library.exception import DnsdbException
 from ..library.log import getLogger
 from ..library.param_validator import ParamValidator
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
 
 CONF = cfg.CONF
 log = getLogger(__name__)
@@ -48,7 +54,7 @@ def authenticate(func):
 def admin_required(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        print current_user
+        print(current_user)
         if not current_user.is_authenticated:
             return abort(401)
         if not current_user.is_administrator:
@@ -118,7 +124,7 @@ def parse_params(param_meta=None, need_username=False):
                 v = params[k]
                 if v is None:
                     params.pop(k)
-                if isinstance(v, (str, unicode)):
+                if isinstance(v, basestring):
                     params[k] = v.strip()
 
             kwargs.update(params)
@@ -204,7 +210,7 @@ def timer(func):
         start = datetime.now()
         result = func(*args, **kwargs)
         end = datetime.now()
-        print func.__name__, (end - start).total_seconds()
+        print(func.__name__, (end - start).total_seconds())
         return result
 
     return _wrap
@@ -214,9 +220,9 @@ def local_notify(func):
     @wraps(func)
     def _wrap(*args, **kwargs):
         if CONF.etc.env == 'local':
-            print '\n______________________________'
-            print u'func: %s\n args: %s\n kwargs:\n %s' % (func.__name__, args, json.dumps(kwargs, indent=4))
-            print '\n______________________________\n'
+            print('\n______________________________')
+            print(u'func: %s\n args: %s\n kwargs:\n %s' % (func.__name__, args, json.dumps(kwargs, indent=4)))
+            print('\n______________________________\n')
             return
         return func(*args, **kwargs)
 

--- a/dnsdb_common/library/email_util.py
+++ b/dnsdb_common/library/email_util.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import smtplib
 from email.header import Header
 from email.mime.text import MIMEText
@@ -7,6 +8,12 @@ from email.mime.text import MIMEText
 from oslo.config import cfg
 
 from ..library.log import getLogger
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
+
 log = getLogger(__name__)
 
 CONF = cfg.CONF
@@ -18,11 +25,11 @@ def send_email(subject, content, sender=None, receivers=None):
     msg = MIMEText(content, 'plain', 'utf-8')
     if sender is None:
         sender = CONF.MAIL.from_addr
-    elif isinstance(sender, (str, unicode)):
+    elif isinstance(sender, basestring):
         raise TypeError('sender should be str type.')
     if receivers is None:
         receivers = CONF.MAIL.info_list
-    elif isinstance(receivers, (str, unicode)):
+    elif isinstance(receivers, basestring):
         raise TypeError('Receivers should be str type.')
     to_list = receivers.split(';')
 
@@ -33,7 +40,7 @@ def send_email(subject, content, sender=None, receivers=None):
     try:
         s.connect(CONF.MAIL.server, CONF.MAIL.port)
         s.sendmail(sender, to_list, msg.as_string())
-    except Exception, e:
+    except Exception as e:
         log.error("Failed to send email:%s, because: %s" % (msg, e.message))
     finally:
         s.close()
@@ -41,7 +48,7 @@ def send_email(subject, content, sender=None, receivers=None):
 
 def send_alert_email(content, sender=None):
     receivers = CONF.MAIL.alert_list
-    print receivers
+    print(receivers)
     subject = "[DNSDB alarm]"
     send_email(subject, content, sender, receivers)
 

--- a/dnsdb_common/library/utils.py
+++ b/dnsdb_common/library/utils.py
@@ -16,6 +16,11 @@ from dnsdb_common.dal.models import DnsSerial
 from dnsdb_common.library.exception import DnsdbException, BadParam
 from dnsdb_common.library.log import getLogger
 
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
+
 log = getLogger(__name__)
 
 CONF = cfg.CONF
@@ -91,9 +96,7 @@ def is_valid_ip_bysocket(ip):
 
 
 def is_string(s):
-    if s is None:
-        return False
-    return type(s) is unicode or type(s) is str
+    return isinstance(s, basestring)
 
 
 def select_best_matched_domain(db, domain_name):

--- a/dnsdb_common/library/validator.py
+++ b/dnsdb_common/library/validator.py
@@ -2,6 +2,11 @@
 
 import re
 
+try:
+    basestring
+except NameError:
+    basestring = (str, )
+
 def _match_pattern(pattern, string):
     ptn = re.search(r'(%s)' % pattern, string)
     if ptn is None:


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.